### PR TITLE
Add infinite reconnection attempts.

### DIFF
--- a/mopidy_async_client/client.py
+++ b/mopidy_async_client/client.py
@@ -73,11 +73,12 @@ class MopidyClient:
             await self.disconnect()
             i = 0
             while self._reconnect_attempts is None or i < self._reconnect_attempts:
-                if self._reconnect_attempts is not None:
+                if self._reconnect_attempts is None:
+                    logger.info("try to reconnect.")
+                else:
                     i += 1  # start with one, because we don't want to catch the last attempt
                     logger.info("try to reconnect. attempt %s / %s", i, self._reconnect_attempts)
-                else:
-                    logger.info("try to reconnect.")
+
                 try:
                     await self.connect()
                     return

--- a/mopidy_async_client/client.py
+++ b/mopidy_async_client/client.py
@@ -71,6 +71,7 @@ class MopidyClient:
     async def _reconnect(self):
         async def _reconnect_():
             await self.disconnect()
+            i = 0
             while self._reconnect_attempts is None or i < self._reconnect_attempts:
                 if self._reconnect_attempts is not None:
                     i += 1  # start with one, because we don't want to catch the last attempt

--- a/mopidy_async_client/client.py
+++ b/mopidy_async_client/client.py
@@ -71,17 +71,19 @@ class MopidyClient:
     async def _reconnect(self):
         async def _reconnect_():
             await self.disconnect()
-            i = 1   # start with one, because we don't want to catch the last attempt
             while self._reconnect_attempts is None or i < self._reconnect_attempts:
+                if self._reconnect_attempts is not None:
+                    i += 1  # start with one, because we don't want to catch the last attempt
+                    logger.info("try to reconnect. attempt %s / %s", i, self._reconnect_attempts)
+                else:
+                    logger.info("try to reconnect.")
                 try:
-                    logging.info(f"try to reconnect. attempt {i} / {self._reconnect_attempts}")
                     await self.connect()
                     return
                 except OSError:
-                    logging.info(f"reconnect failed. new attempt in {self._reconnect_timeout} sec")
+                    logger.info("reconnect failed. new attempt in %s sec", self._reconnect_timeout)
                     await asyncio.sleep(self._reconnect_timeout)
-                if self._reconnect_attempts is not None:
-                    i += 1
+
             await self.connect()  # not catching last attempt
 
         self._loop.create_task(_reconnect_())  # this task will be closed so creating new one

--- a/mopidy_async_client/client.py
+++ b/mopidy_async_client/client.py
@@ -71,7 +71,8 @@ class MopidyClient:
     async def _reconnect(self):
         async def _reconnect_():
             await self.disconnect()
-            for i in range(self._reconnect_attempts - 1):
+            i = 1   # start with one, because we don't want to catch the last attempt
+            while self._reconnect_attempts is None or i < self._reconnect_attempts:
                 try:
                     logging.info(f"try to reconnect. attempt {i} / {self._reconnect_attempts}")
                     await self.connect()
@@ -79,6 +80,8 @@ class MopidyClient:
                 except OSError:
                     logging.info(f"reconnect failed. new attempt in {self._reconnect_timeout} sec")
                     await asyncio.sleep(self._reconnect_timeout)
+                if self._reconnect_attempts is not None:
+                    i += 1
             await self.connect()  # not catching last attempt
 
         self._loop.create_task(_reconnect_())  # this task will be closed so creating new one


### PR DESCRIPTION
If the parameter `reconnect_attempts` in `MopidyClient.__init__()` is set to `None`, try to connect indefinitely.