### PR TITLE
Downgrade timeout errors of requests

### DIFF
--- a/mopidy_async_client/client.py
+++ b/mopidy_async_client/client.py
@@ -102,6 +102,8 @@ class MopidyClient:
         except websockets.ConnectionClosed:
             await self._reconnect()
             await self._request(method, **kwargs)
+        except asyncio.TimeoutError:
+            logger.warning("Timeout waiting for request %s", request)
         except Exception as ex:
             logger.exception(ex)
             return None


### PR DESCRIPTION
Sometimes a request times out. The old behaviour was to log an exception, but IMHO a warning would suffice.

A timeout in answering a request might contribute to the count of connection retries, but this is not implemented with this PR.